### PR TITLE
Create main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published] # on release also
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Docker Login
+        uses: docker/login-action@v3.5.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      # --- BACKEND ---
+      - name: Docker Metadata (Backend)
+        id: meta-back
+        uses: docker/metadata-action@v5.8.0
+        with: 
+          images: eugiovannicruz/pokedex-plus-backend
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.release.prerelease == false) }}
+      
+      - name: Build & Push Backend
+        uses: docker/build-push-action@v4
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta-back.outputs.tags }}
+          labels: ${{ steps.meta-back.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # --- FRONTEND ---
+      - name: Docker Metadata (Frontend)
+        id: meta-front
+        uses: docker/metadata-action@v5.8.0
+        with: 
+          images: eugiovannicruz/pokedex-plus-frontend
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.release.prerelease == false) }}
+      
+      - name: Build & Push Frontend
+        uses: docker/build-push-action@v4
+        with:
+          context: ./frontend/pokedex-plus
+          push: true
+          tags: ${{ steps.meta-front.outputs.tags }}
+          labels: ${{ steps.meta-front.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request introduces a new CI workflow using GitHub Actions to automate Docker image building and publishing for both backend and frontend services. The workflow is triggered on pushes to the `main` branch and when a release is published. The most important changes are grouped below:

**Continuous Integration Workflow Setup:**

* Added `.github/workflows/main.yml` to define a CI pipeline that runs on pushes to `main` and published releases.

**Docker Build and Publish Automation:**

* Configured Docker login using GitHub secrets for secure authentication with Docker Hub.
* Set up Docker metadata and build/push steps for the backend, including tagging strategies for versioning and latest images.
* Set up Docker metadata and build/push steps for the frontend, with similar tagging and caching strategies as the backend.