### PR TITLE
fix: corrige referência ao token do GitHub no workflow de release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         id: semrel
         uses: cycjimmy/semantic-release-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           extra_plugins: |
             @semantic-release/commit-analyzer


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change corrects the environment variable name used for the GitHub token in the semantic release step.