### PR TITLE
feat: update CI workflows to use Ubuntu 24.04 and add cache for depen…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     name: Backend build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: backend
@@ -18,15 +25,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
       - name: Install deps
-        run: |
-          if [ -f package-lock.json ]; then npm ci; else npm install; fi
-      - name: TypeScript build
+        run: npm ci
+
+      - name: Build
         run: npm run build
 
   frontend:
     name: Frontend build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: backend
     defaults:
       run:
@@ -36,8 +46,29 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: frontend/pokedex-plus/package-lock.json
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            frontend/pokedex-plus/.next/cache
+          key: nextcache-${{ runner.os }}-v1-${{ hashFiles('frontend/pokedex-plus/package-lock.json', 'frontend/pokedex-plus/package.json', 'frontend/pokedex-plus/next.config.*', 'frontend/pokedex-plus/tsconfig.json', 'frontend/pokedex-plus/.babelrc', 'frontend/pokedex-plus/.env.production') }}
+          restore-keys: |
+            nextcache-${{ runner.os }}-v1-
+            nextcache-${{ runner.os }}-
+
       - name: Install deps
-        run: |
-          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+        run: npm ci
+
+      # - name: Typecheck/Tests
+      #   run: |
+      #     npm run typecheck --if-present
+      #     npm test --if-present
+
       - name: Next build
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          CI: "true"
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,12 +49,14 @@ jobs:
         if: steps.semrel.outputs.new_release_published == 'true'
         shell: bash
         run: |
-          echo "version=${{ steps.semrel.outputs.new_release_version }}" >> $GITHUB_OUTPUT
           ver='${{ steps.semrel.outputs.new_release_version }}'
-          major=$(echo "$ver" | awk -F. '{print $1}')
-          minor=$(echo "$ver" | awk -F. '{print $2}')
+          echo "version=$ver" >> $GITHUB_OUTPUT
+          major=$(echo "$ver" | cut -d. -f1)
+          minor=$(echo "$ver" | cut -d. -f2)
           echo "major=$major" >> $GITHUB_OUTPUT
           echo "minor=$minor" >> $GITHUB_OUTPUT
+          # Flag "stable" só se major >= 1
+          if [ "$major" -ge 1 ]; then echo "stable=true" >> $GITHUB_OUTPUT; else echo "stable=false" >> $GITHUB_OUTPUT; fi
 
       - name: Docker Login
         if: steps.semrel.outputs.new_release_published == 'true'
@@ -63,28 +65,58 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      # --- BACKEND ---
+      - name: Setup QEMU
+        if: steps.semrel.outputs.new_release_published == 'true'
+        uses: docker/setup-qemu-action@v3.6.0
+
+      - name: Setup Buildx
+        if: steps.semrel.outputs.new_release_published == 'true'
+        uses: docker/setup-buildx-action@v3.11.1
+
+      # --- BACKEND METADATA ---
+      - name: Docker metadata (backend)
+        id: meta_backend
+        if: steps.semrel.outputs.new_release_published == 'true'
+        uses: docker/metadata-action@v5.8.0
+        with:
+          images: docker.io/eugiovannicruz/pokedex-plus-backend
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+            type=raw,value=${{ steps.version.outputs.major }}
+            ${{ steps.version.outputs.stable == 'true' && 'type=raw,value=latest' || '' }}
+
+      # --- BACKEND BUILD & PUSH ---
       - name: Build & Push Backend
         if: steps.semrel.outputs.new_release_published == 'true'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6.18.0
         with:
           context: ./backend
           push: true
-          tags: |
-            eugiovannicruz/pokedex-plus-backend:${{ steps.version.outputs.version }}
-            eugiovannicruz/pokedex-plus-backend:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-            eugiovannicruz/pokedex-plus-backend:${{ steps.version.outputs.major }}
-            eugiovannicruz/pokedex-plus-backend:latest
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_backend.outputs.tags }}
+          labels: ${{ steps.meta_backend.outputs.labels }}
 
-      # --- FRONTEND ---
+      # --- FRONTEND METADATA ---
+      - name: Docker metadata (frontend)
+        id: meta_frontend
+        if: steps.semrel.outputs.new_release_published == 'true'
+        uses: docker/metadata-action@v5.8.0
+        with:
+          images: docker.io/eugiovannicruz/pokedex-plus-frontend
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+            type=raw,value=${{ steps.version.outputs.major }}
+            ${{ steps.version.outputs.stable == 'true' && 'type=raw,value=latest' || '' }}
+
+      # --- FRONTEND BUILD & PUSH ---
       - name: Build & Push Frontend
         if: steps.semrel.outputs.new_release_published == 'true'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6.18.0
         with:
           context: ./frontend/pokedex-plus
           push: true
-          tags: |
-            eugiovannicruz/pokedex-plus-frontend:${{ steps.version.outputs.version }}
-            eugiovannicruz/pokedex-plus-frontend:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-            eugiovannicruz/pokedex-plus-frontend:${{ steps.version.outputs.major }}
-            eugiovannicruz/pokedex-plus-frontend:latest
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_frontend.outputs.tags }}
+          labels: ${{ steps.meta_frontend.outputs.labels }}


### PR DESCRIPTION
This pull request updates the CI/CD workflow configuration to improve build efficiency, caching, and Docker image publishing for both backend and frontend services. The main changes include upgrading the runner OS, optimizing dependency caching, enhancing Docker build and tagging logic, and improving platform support for Docker images.

### CI workflow improvements

* Upgraded GitHub Actions runner from `ubuntu-latest` to `ubuntu-24.04` for both backend and frontend jobs, ensuring compatibility with newer environments. (`.github/workflows/ci.yml`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R19) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR28-R39)
* Added `permissions` and `concurrency` settings to the workflow for better security and to prevent overlapping CI runs. (`.github/workflows/ci.yml`)
* Enabled Node.js and npm caching for both backend and frontend builds, and added Next.js cache restoration for faster frontend builds. (`.github/workflows/ci.yml`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR28-R39) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR49-R73)

### Docker build and publish enhancements

* Added QEMU and Buildx setup steps to support multi-platform Docker builds (amd64 and arm64). (`.github/workflows/main.yml`)
* Introduced Docker metadata actions for both backend and frontend to manage image tags and labels dynamically, including logic for "latest" tags only on stable releases. (`.github/workflows/main.yml`)
* Upgraded Docker build-push-action to v6.x and refactored image tagging to use outputs from metadata actions, supporting multi-platform builds and improved tagging consistency. (`.github/workflows/main.yml`)

### Minor shell and logic updates

* Refactored shell logic for version extraction to use `cut` instead of `awk`, and added a step to flag releases as "stable" when major version is at least 1. (`.github/workflows/main.yml`)…dencies