### PR TITLE
chore: add .dockerignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ node_modules/
 .npm
 
 # Docker
-.dockerignore
+# .dockerignore
 
 # IDE
 .vscode/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,34 @@
+# Local dependencies (reinstalled inside the container)
+node_modules
+
+# Build output generated inside the container
+dist
+
+# Logs & diagnostics
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+logs
+*.log
+
+# Env / secrets
+.env
+.env.*
+
+# Version control / metadata
+.git
+.gitignore
+
+# IDE / editor settings
+.vscode
+.idea
+
+# System / infrastructure
+Dockerfile*
+docker-compose*.yml
+*.swp
+*~
+
+# OS specific / system artifacts
+Thumbs.db
+.DS_Store

--- a/frontend/pokedex-plus/.dockerignore
+++ b/frontend/pokedex-plus/.dockerignore
@@ -1,0 +1,36 @@
+# Local dependencies
+node_modules
+
+# Build output (Next.js)
+.next
+out
+build
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+logs
+*.log
+
+# Env / secrets
+.env
+.env.*
+
+# Version control / metadata
+.git
+.gitignore
+
+# IDE / editor settings
+.vscode
+.idea
+
+# System / infrastructure
+Dockerfile*
+docker-compose*.yml
+*.swp
+*~
+
+# OS specific / system artifacts
+Thumbs.db
+.DS_Store


### PR DESCRIPTION
This pull request adds `.dockerignore` files to both the backend and frontend projects to optimize Docker builds and improve security. The new files ensure that unnecessary files, local dependencies, build outputs, logs, secrets, and system artifacts are excluded from Docker images.

Docker build optimization and security:

* Added `.dockerignore` to `backend/` to exclude dependencies (`node_modules`), build outputs (`dist`), logs, environment files, version control data, editor settings, infrastructure files, and OS artifacts from Docker images.
* Added `.dockerignore` to `frontend/pokedex-plus/` to exclude similar categories: dependencies, Next.js build outputs, logs, environment files, version control data, editor settings, infrastructure files, and OS artifacts.