### PR TITLE
chore: remove Dockerfile and docker-compose references from .dockerig…

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -24,8 +24,6 @@ logs
 .idea
 
 # System / infrastructure
-Dockerfile*
-docker-compose*.yml
 *.swp
 *~
 

--- a/frontend/pokedex-plus/.dockerignore
+++ b/frontend/pokedex-plus/.dockerignore
@@ -26,8 +26,6 @@ logs
 .idea
 
 # System / infrastructure
-Dockerfile*
-docker-compose*.yml
 *.swp
 *~
 


### PR DESCRIPTION
This pull request makes a small update to the `.dockerignore` files for both the backend and frontend projects. The change removes the exclusion of `Dockerfile*` and `docker-compose*.yml` from the ignore list, allowing these files to be included in the build context.

- [`backend/.dockerignore`](diffhunk://#diff-b148396bbfff0ab728abd0f4ecccb2d94ee1929bebbfdcb301a1818a7fa8a351L27-L28): Removed lines that ignored `Dockerfile*` and `docker-compose*.yml`.
- [`frontend/pokedex-plus/.dockerignore`](diffhunk://#diff-5a3112f7ecf1ba0600f12defab56ad054e0cf122137ae43aa8b9a85fadd8978aL29-L30): Removed lines that ignored `Dockerfile*` and `docker-compose*.yml`.…nore files